### PR TITLE
Changes for item 6: changeset R,  :extend_alap option

### DIFF
--- a/call-basics.adoc
+++ b/call-basics.adoc
@@ -660,7 +660,7 @@ This  +expiration_time+ argument of <<Renew>> call and the +:end_time+ option of
 
 The +:end_time+ argument/option requests an expiration of the specified slivers. It is in dateTime.!rfc3339 format (defined above). 
 
-When an explicit argument (<<Renew>>), it is required, and aggregates must honor the request to the extent local policy permits. They must return an error if they cannot honor this argument.
+When an explicit argument (<<Renew>>), it is required, and aggregates must honor the request to the extent local policy permits. They must return an error if they cannot honor this argument. Note that the +:extend_alap+ option changes this behaviour, allowing the AM to extend "as long as possible" instead.
 
 When +:end_time+ is an option in the options struct (<<Provision>> and <<Allocate>>), clients may omit the option, and AMs may choose not to or be unable to honor this option, but may still succeed the overall request. If +:end_time+ is supplied, the experimenter is requesting a particular sliver reservation expiration date. Local policy may however dictate the expiration date. The AM therefore may ignore this argument; the call should still succeed, even if the date argument cannot be satisfied. 
 

--- a/call-renew.adoc
+++ b/call-renew.adoc
@@ -48,6 +48,27 @@ See <<CommonOptionBestEffort, +:best_effort+ option>> for details.
 
 Specifying whether the client prefers all included slivers to be renewed or none, or wants a partial success if possible.
 
+=== Option: +:extend_alap+ 
+
+***********************************
+[horizontal]
+Supported by the server:: Mandatory
+Included by client:: Optional
+XML-RPC type:: +boolean+
+Default:: false
+***********************************
+
+ALAP stands for "as long as possible". When +true+, the AM should extend the life of the sliver, to the minimum of the requested new expiration time, the expiration time in the slice credential (of course), and the AM local maximum based on local policy (which may be resource or slice dependent).
+
+When the AM successfully extends the life of the slice/sliver using this new option, the return value is success.
+
+When the AM cannot extend the life of the slice/sliver at all, then it fails the request, returning an error code unless +:best_effort+ is +true+, in which case it may return success and indicate the individual per-sliver errors in the return struct. 
+
+//////////////////////
+When the AM cannot extend the life of the slice/sliver at all (because it does not honor the new option, or because no expiration is possible)
+The error code may be one of UNSUPPORTED for an AM that does not support this option, or BADARGS or ERROR for other failures.
+//////////////////////
+
 ==== Return Value
 
 ***********************************


### PR DESCRIPTION
Item 2 from google doc: Change Set R

Was agreed to adopt, BUT might need some additional discussion because I changed something:
In the original proposal, this option is optional to support by server, to make things easily backwards compatible with existing servers.
However, since the federation AM API is not backwards compatible (dropping the geni_ prefix among other things, means that new server code has to be written for it), I think it is to be decided if this option is mandatory to be supported by the server. If not, the server could just ignore the option. But as this is a useful and easy to implement option, it is probably best to make it mandatory for it to be supported by the server.

This pull request already assumes the option is mandatory.
