### PR TITLE
Discussion: Allow or disallow <nil/> ?

### DIFF
--- a/call-basics.adoc
+++ b/call-basics.adoc
@@ -442,7 +442,8 @@ The following primitive types are always sent using the matching XML-RPC data ty
 The +array+ and +struct+ types are used to create complex data types.
 
 Note that the following XML-RPC types are NOT used: +base64+ and +dateTime.iso8601+.
-The +nil+ type is also not used (this is an XML-RPC extension).
+
+The +nil+ type is an XML-RPC extension, but should also be supported, in case any options use it.
 
 === Compressed data
 


### PR DESCRIPTION
This is a about issue 33 on the google doc
Text from google doc: "XMLRPC extension <nil/> -- discussion on github, should be specified if nil is supported , likely to be have to be supported "

In the original AMv3 API, <nil/> is not mentioned at all.
In the current first draft of the API, <nil/> is explicitly disallowed.
This pull request would allow <nil/>. Clients and servers would have to support the nil XML-RPC extension.

Personally, I think it is not a good idea to support this for two reasons:
- It is currently not used anywhere in the API, and it can very likely be avoided in additions
- It's possible that not all XML-RPC libraries support it, which could cause implementation difficulties.

In case nil is not supported, it might need to be put even more explicitly in the API. In case it needs to be supported, more explanation is probably needed in the API (including a link to the page describing this XML-RPC extension).
