### PR TITLE
Proposal: Return value in case of :best_effort

### DIFF
--- a/call-basics.adoc
+++ b/call-basics.adoc
@@ -838,7 +838,7 @@ NOTE: *TODO: this is a very common return. Each call has only minor differences.
   }
 ------------------
 
-==== +:error+
+==== +:error_output+
 
 NOTE: *TODO this section was copied from the AMv3 spec with only minor changes (mostly markup). This sections content might still be moved to better places.*
 


### PR DESCRIPTION
## Main proposal

This is a proposal about the return value for the case if `:best_effort` is true but at least one sliver fails, because for example it has expired.

This is not a fully worked out text yet. This only updates the syntax of the returned sliver info list, and adds examples. I hope the proposal is clear in that way. I will add text describing it later.

The basic change is that AMv3 returned one field (`geni_error`), and this proposal splits this in 2 fields: `:error_code` and `:error_output`.

This way, the return can be SUCCESS, while there are appropriate error codes given for slivers that failed.

Let's discuss if this is a good idea or not, and how this can be improved or done in another way. I will update the text and example when needed.
## Related question

There is also another open question related very much to this, for which feedback is welcome:
When `:best_effort` is true, and all slivers given fail for some reason, does the entire call return SUCCESS, or does it return some error?

I would personally propose that it still returns SUCCESS, even in this case, due to the `:best_effort`, and that the appropriate error codes are mentioned in the list of slivers. Note that this can occur if only a single sliver URN is specified with  `:best_effort`.

Any thoughts on this? 
## Side note

 I'm already using this syntax in issue 18: https://github.com/open-multinet/federation-am-api/pull/18
This proposal and that one are related.
