### PR TITLE
Question: Do we need to mentioned differences with AMv2/v3 inside the API? Or in seperate sections?

### DIFF
--- a/call-allocate.adoc
+++ b/call-allocate.adoc
@@ -14,10 +14,6 @@ Allocate(string slice_urn,
          struct options)
 ----------------
 
-NOTE: This is the first part of what CreateSliver used to do in previous versions of the AM API. The second part is now done by <<Provision>>, and the final part is done by <<PerformOperationalAction>>. 
-
-NOTE: This operation is similar to ProtoGENI's GetTicket operation.
-
 As described in the <<OperationsOnIndividualSlivers, Operations On Individual Slivers>> section, the :allocate return from <<GetVersion>> advertises when a client may legally call Allocate (only once at a time per slice, whenever desired, or multiple times only if the requested resources do not interact).
 
 ==== Argument 1: +slice_urn+

--- a/call-basics.adoc
+++ b/call-basics.adoc
@@ -338,11 +338,11 @@ If the transition from one state to another fails, the sliver shall remain in it
 
 Several AM API methods can be described in terms of transitions among allocation states.
 
-- <<Allocate>> moves 1 or more slivers from +:unallocated+ (state 1) to +:allocated+ (state 2). This method can be described as creating an instance of the state machine for each sliver. If the aggregate cannot fully satisfy the request, the whole request fails. This is a change from the AM API V2 CreateSliver, which also provisioned the resources, and 'started' them. That is <<Allocate>> does one of the three things that CreateSliver did previously.
-- <<Delete>> moves 1 or more slivers from either state 2 or 3 (+:allocated+ or +:provisioned),+ back to state 1 (+:unallocated).+ This is similar to the AM API AM API V2 DeleteSliver.
+- <<Allocate>> moves 1 or more slivers from +:unallocated+ (state 1) to +:allocated+ (state 2). This method can be described as creating an instance of the state machine for each sliver. If the aggregate cannot fully satisfy the request, the whole request fails.
+- <<Delete>> moves 1 or more slivers from either state 2 or 3 (+:allocated+ or +:provisioned),+ back to state 1 (+:unallocated).+
 - <<Renew>>, when given slivers in state 2 (+:allocated+ state), requests an extended timeout.
 - <<Renew>>, when given slivers in state 3 (+:provisioned+ state) will request and extended sliver expiration timeout. That is, this method's semantics can be the same as RenewSliver from AM API v2.
-- <<Provision>> moves 1 or more slivers from state 2 (+:allocated)+ to state 3 (+:provisioned).+ This is some of what AM API V2 CreateSliver did. Note however that this does not 'start' the resources, or otherwise change their operational state (<<PerformOperationalAction>> does that). This method only fully instantiates the resources in the slice. This may be a no-op for some aggregates or resources. 
+- <<Provision>> moves 1 or more slivers from state 2 (+:allocated)+ to state 3 (+:provisioned).+ Note that this does not 'start' the resources, or otherwise change their operational state (<<PerformOperationalAction>> does that). This method only fully instantiates the resources in the slice. This may be a no-op for some aggregates or resources. 
 
 When <<Provision>> fails for only some slivers, and +:best_effort+ option was supplied, the aggregate will return the status of each requested sliver individually. The +:allocation_state+ for slivers that failed will remain +:allocated.+ This typically suggests that the experimenter may retry the call. For some aggregates or resource types, the sliver may be 'dead', and <<Provision>> may never succeed. Experimenters should check +:error+ for more information.
 

--- a/call-delete.adoc
+++ b/call-delete.adoc
@@ -9,10 +9,6 @@ Delete the named slivers, making them +:unallocated+. Resources are stopped if n
 Delete(string urns[], struct credentials[], struct options)
 ----------------
 
-NOTE: This operation used to be called +DeleteSliver+ in earlier versions of this API. To get the functionality of +DeleteSliver+, call +Delete+ with the slice URN.
-
-NOTE: This operation is similar to ProtoGENI's  +DeleteSliver+ operation and to  SFA's +DeleteSlice+ operation (sec. 6.2.3).
-
 As described here, the +:single_allocation+ return from <<GetVersion>> advertises whether or not a client may invoke this method on only some of the slivers in a given +:allocation_state+ in a given slice (default is false - the client may operate on only some of the slivers in a given state).
 
 +Delete+ the given slivers, stopping any running resources and freeing the reservation. This method applies to slivers in any state.

--- a/call-describe.adoc
+++ b/call-describe.adoc
@@ -17,10 +17,6 @@ Describe(string urns[], struct credentials[],
          struct rspec_version, struct options[])
 ----------------
 
-
-NOTE: This method is part of what +ListResources+ used to do in previous versions of the AM API, and is similar to ProtoGENI  `Resolve`.
-
-
 ==== Argument 1:  +urns+
 
 See the <<CommonArgumentUrns, +urns+ argument>> for details.

--- a/call-performoperationalaction.adoc
+++ b/call-performoperationalaction.adoc
@@ -14,13 +14,9 @@ PerformOperationalAction (string urns[], struct credentials[], string action,
                           struct options={})
 ----------------
 
-NOTE: This operation is similar to ProtoGENI functions like StartSliver, StopSliver, and RestartSliver in the  PG CMv2 API.
-
 Aggregate Managers SHOULD return an error code of 13 (UNSUPPORTED) if they do not support a given action for a given resource. An AM SHOULD constrain actions based on the current operational state of the resource. This is a fast synchronous operation, and MAY start long-running sliver transitions whose status can be queried using <<Status>>. This method should only be called, and is only valid, when the sliver is fully allocated (operational status is not +:pending_allocation+).
 
 While the action argument may be aggregate and sliver type specific (none are required for all aggregates and sliver types), this API does define three common actions that AMs should support if possible: +:start+, +:stop+, and +:restart+. 
-
-NOTE: Calling +PerformOperationalAction+ with the action +:start+ corresponds to the final part of what CreateSliver did in AM API v2. 
 
 ==== Argument 1:  +urns+
 

--- a/call-provision.adoc
+++ b/call-provision.adoc
@@ -14,10 +14,7 @@ Provision(string urns[], struct credentials[],
           struct rspec_version, struct options)
 ----------------
 
-NOTE: This operation is part of what CreateSliver used to do. The first part of what CreateSliver did is now in <<Allocate>>. This operation is similar to ProtoGENI's  RedeemTicket method.
-
 NOTE: Note that resources are not necessarily ready for experimenter use after the work that this function initiates finally completes. Consult the :operational_status, and the advertised operational state machine. Consider calling <<PerformOperationalAction>>, e.g. with the command name :start.
-
 
 As described in the <<OperationsOnIndividualSlivers, Operations On Individual Slivers>> section, the +:single_allocation+ return from <<GetVersion>> advertises whether or not a client may invoke this method on only some of the slivers in a given +:allocation_state+ in a given slice (default is false - the client may operate on only some of the slivers in a given state).
 

--- a/call-renew.adoc
+++ b/call-renew.adoc
@@ -12,13 +12,9 @@ Renew(string urns[],
       struct options)
 ----------------
 
-NOTE: This operation used to be called +RenewSliver+. Use +Renew+(<slice_urn>) to get the equivalent functionality.
-
-
 When +Renew+ is called with +:best_effort+ false, the entire method will fail (return non-zero +:code+) if any requested sliver cannot be renewed to the requested time, and all slivers will keep their original expiration time. When +Renew+ is called with +:best_effort+ true, some slivers may fail to be renewed. In this case, the allocation state and expiration times do not change. +:error+ may optionally be returned by the aggregate to explain this failure.
 
 As described in the <<OperationsOnIndividualSlivers, Operations On Individual Slivers>> section, the +:single_allocation+ return from <<GetVersion>> advertises whether or not a client may invoke this method on only some of the slivers in a given +:allocation_state+ in a given slice (default is false - the client may operate on only some of the slivers in a given state).
-
 
 +Renew+ requests a changed expiration for one or more slivers in a slice. At some aggregates, this expiration may be shorter. This method applies both to slivers that are +:allocated+ and to those that are already +:provisioned+. Depending on local aggregate configuration, the aggregate may only support +Renew+ on all current slivers in the slice, or may permit renewing only some slivers. Local policy will dictate maximum expiration times. These times are typically quite short (\~ 10 minutes initially, \~ 120 minutes maximum) for reservations (+:allocated+), and longer for provisioned (+:provisioned+) slivers (~ 5-8 days initially). Since these expiration times are different, typically +Renew+ is used only for slivers in the same allocation state. 
 

--- a/call-status.adoc
+++ b/call-status.adoc
@@ -11,8 +11,6 @@ In contrast to <<Describe>>, +Status+ is used to query dynamic state information
 Status(string urns[], struct credentials[], struct options)
 ----------------
 
-NOTE: This operation used to be called +SliverStatus+ in earlier versions of the AM API. :slivers has replaced :resources and :sliver_urn replaces :urn. :status is replaced with 2 fields, :allocation_status and :operational_status.
-
 ==== Argument 1:  +urns+
 
 See the <<CommonArgumentUrns, +urns+ argument>> for details.

--- a/federation-am-api.adoc
+++ b/federation-am-api.adoc
@@ -48,5 +48,54 @@ include::call-shutdown.adoc[tabsize=4]
 
 == Releation to other API's
 
-NOTE: *TODO* add a section here that desribes the relation between this API and other API's, such as the Geni AMv2 and AMv3 APIs. Incompatabilities should be listed.
+This section compares the methods of this API to other API's, such as the link:http://www.protogeni.net/wiki/ComponentManagerAPIV2[ProtoGeni CM v2 API] and the link:http://groups.geni.net/geni/wiki/GAPI_AM_API_V2[Geni AM v2 API].
+
+In particular, the notable differences with the link:http://groups.geni.net/geni/wiki/GAPI_AM_API_V3[Geni AM v3 API], on which this API is based, are listed. General differences, like replacing the +geni_+ prefix with a colon +:+ are not mentioned for each command.
+
+<<GetVersion>>::
+    ProtoGENI;; The +GetVersion+ methods have a same name and purpose, but the information returned is in a completely different format.
+    Geni AM v2 API;; This is the same as +GetVersion+ but contains more information.
+    Geni AM v3 API;; This is mostly the same, however, the format is not compatible due to dropping the +geni_+ prefix. Also, some extra info is added by this API: +:am_code_version+ and +:am_type+
+
+<<Allocate>>::
+    ProtoGENI;; This operation is similar to the +GetTicket+ operation.
+    Geni AM v2 API;; This is the first part of what +CreateSliver+ does. The second part is done by <<Provision>>, and the final part is done by <<PerformOperationalAction>>. So +CreateSliver+ also provisions the resources, and 'starts' them.
+    Geni AM v3 API;; This API changes +rspec_version+ into a mandatory argument instead of a mandatory option. 
+
+<<Provision>>::
+    ProtoGENI;; This operation is similar to the +RedeemTicket+ method.
+    Geni AM v2 API;; This operation is part of what +CreateSliver+ does. The first part of what +CreateSliver+ does is <<Allocate>>. Note that this does not 'start' the resources, or otherwise change their operational state (<<PerformOperationalAction>> does that).
+    Geni AM v3 API;; This API changes +rspec_version+ into a mandatory argument instead of a mandatory option.
+
+<<PerformOperationalAction>>::
+    ProtoGENI;; This operation is similar to functions like +StartSliver+, +StopSliver+, and +RestartSliver+ in the PG CMv2 API.
+    Geni AM v2 API;; Calling +PerformOperationalAction+ with the action +:start+ corresponds to the final part of what +CreateSliver+ does.
+    Geni AM v3 API;; This API adds an +:update_users+ action.
+
+<<ListResources>>::
+    ProtoGeni;; This operation is similar to the +DiscoverResources+ method.
+    Geni AM v2 API;; This method is what +ListResources+ does when called without a slice URN argument.
+    Geni AM v3 API;; This API changes +rspec_version+ into a mandatory argument instead of a mandatory option.
+
+
+<<Describe>>::
+    ProtoGENI;; This operation is similar to the +Resolve+ method.
+    Geni AM v2 API;; This method is what +ListResources+ does when called with a slice URN argument.
+    Geni AM v3 API;; This API changes +rspec_version+ into a mandatory argument instead of a mandatory option.
+
+<<Status>>::
+    ProtoGENI;;  This operation is similar to the +SliverStatus+ method.
+    Geni AM v2 API;; This method correseponds to the +SliverStatus+ method. +:slivers+ replaces +geni_resources+ and +:sliver_urn+ replaces +geni_urn+. +geni_status+ is replaced with 2 fields: +:allocation_status+ and +:operational_status+
+    Geni AM v3 API;; similar.
+
+<<Delete>>:: 
+    ProtoGENI;; This operation is similar to the +DeleteSliver+ operation.
+    SFA;; This operation is similar to the +DeleteSlice+ operation (sec. 6.2.3).
+    Geni AM v2 API;; This method correseponds to the +DeleteSliver+ method. To get the functionality of +DeleteSliver+, call +Delete+ with the slice URN.
+    Geni AM v3 API;; similar.
+
+<<Renew>>::
+    ProtoGENI;; This operation is similar to the +RenewSlice+ method.
+    Geni AM v2 API;; This operation is similar to the +RenewSliver+. Use +Renew+(<slice_urn>) to get the equivalent functionality.
+    Geni AM v3 API;; This API adds the +:extend_alap+ option.
 


### PR DESCRIPTION
In a lot of places, there are references to the Geni AMv2 API.

Do we need to keep these inside the API itself?
Perhaps they are better placed in a separate section at the end, which explains the differences? 
Such a section has already been added for the differences with the Geni AMv3 API (note that that section is still empty currently, it needs to be updated).
