### PR TITLE
Removed backward compatability with Geni AMv1 API.

### DIFF
--- a/call-getversion.adoc
+++ b/call-getversion.adoc
@@ -76,10 +76,6 @@ struct value
 
 +GetVersion+ returns the standard return struct from all AM API methods (output, value, code). See <<ReturnStructure,Return Structure>>.
 
-However, next to the standard AM API +code+, +value+, and +output+ entries, +GetVersion+ adds a +geni_api+ integer version of this API (3) to the return structure. This information is also in the +value+ struct but is repeated here for backwards compatibility with AM API v1 clients.
-
-NOTE: *TODO Is the above still useful for this API, as it is not backward compatible? If so, what number do we fill in (a fake large one)?*
-
 +GetVersion+ is intended to provide information about the configuration of this aggregate, helping experimenter tools determine how to communicate with this aggregate.
 The information returned includes the version of the Aggregate Manager API running locally, the RSpec schemas supported, and the URLs where versions of the AM API are running.
 


### PR DESCRIPTION
The Geni AMv3 API return structure has a special exception in GetVersion, for backward compatibility with Geni AMv1: 
Next to "code", "output" and "value", the return struct for the getVersion call also contains "geni_api" (which is a duplicate of the "geni_api" in the "value").

This was copied in the federation AM API. However, I don't think this has any use, so I propose we remove it.
