### PR TITLE
Proposal: Add RSpec version to Allocate

### DIFF
--- a/call-allocate.adoc
+++ b/call-allocate.adoc
@@ -10,7 +10,8 @@ At some aggregates, experimenter tools may call Allocate multiple times, to add 
 ----------------
 Allocate(string slice_urn,
          struct credentials[],
-         string.rspec rspec,
+         struct request_rspec,
+         struct manifest_rspec_version,
          struct options)
 ----------------
 
@@ -28,25 +29,43 @@ String content type::  URN
 
 The URN of the slice to which the resources specified in rspec will be allocated. For details on URN identifiers, see link:general.html[this document].
 
-==== Argument 2: +rspec+
+==== Argument 2: +credentials+
+
+The standard authorization argument. See <<CommonArgumentCredentials, the Credentials section>>.
+
+==== Argument 3: +request_rspec+
 
 ***********************************
 [horizontal]
 Supported by the server:: Mandatory
 Included by client:: Mandatory
-XML-RPC type::  +string+
-String content type::  <<StringRspecDataType, +string.rspec+>>
+XML-RPC type:: 
+[source]
+  {
+      "type" : <string: (case insensitive, matching '^[a-zA-Z0-9][a-zA-Z0-9-_\.:]*$')>,
+      "version" : <string: (case insensitive, matching '^[a-zA-Z0-9][a-zA-Z0-9-_\.:]*$')>,
+      "rspec" : <string.rspec rspec>
+  }
+
+"rspec" String content type::  <<StringRspecDataType, +string.rspec+>>
 ***********************************
 
-An RSpec containing the resources that the caller is requesting for allocation to the slice specified in slice_urn. These are expected to be consistent with the resources returned by a previous invocation of <<ListResources>>. If this RSpec is in a format not listed as supported by <<GetVersion>>, then the aggregate will return an error of +BADVERSION (4)+.
+A request RSpec containing the resources that the caller is requesting for allocation to the slice specified in +slice_urn+. 
+These are expected to be consistent with the resources returned by a previous invocation of <<ListResources>>. 
+
+The format of the request RSpec is specified in the "version" and "type" fields, the request RSpec itself is specified in "rspec".
+If this RSpec is in a format not listed as supported by <<GetVersion>>, then the aggregate will return an error of +BADVERSION (4)+.
 
 For more details on RSpecs and RSpec versions, see the type <<StringRspecDataType, +string.rspec+>> and the link:rspec.html[Rspec Document].
 
-==== Argument 3: +credentials+
+==== Argument 4: +manifest_rspec_version+
 
-The standard authorization argument. See <<CommonArgumentCredentials, the Credentials section>>.
+The version of (manifest) RSpec that the client would like to receive in the reply to this call.
+If this is not a format listed as supported by <<GetVersion>>, then the aggregate will return an error of +BADVERSION (4)+.
 
-==== Argument 4:  +options+
+See the <<CommonArgumentRspecVersion, +rspec_version+ argument>> for details.
+
+==== Argument 5:  +options+
 
 A struct containing optional arguments, indexed by name. See <<OptionsArgument,General Options Argument Section>>.
 


### PR DESCRIPTION
# Context:

The following calls return an RSpec:
- Allocate (manifest)
- Provision (manifest)
- Describe (manifest)
- ListResources (advertisement)

The following calls take an RSpec as argument:
- Allocate (request)
# Problem:

Allocate is the only one of the calls that returns an RSpec, but does not have the mandatory rspec_version argument that specifies in which format it needs to be returned. (It does not even have this argument as an option.)

Additionally, Allocate takes a request RSpec as mandatory parameter, but users cannot specify in which format this request RSpec is. So I guess the server needs to figure this out. This makes it harder for servers that supports multiple request RSpec formats: they needs to be able to determine the type of the RSpec. Assuming RSpecs are always XML, this might be easy (using the namespace), but that is perhaps not always a valid assumption?
# Solution:

I propose to add the rspec_version argument to Allocate, for both the argument RSpec and the return RSpec. Is this a good idea? Any feedback on this?
## Alternative solution

Note that AMv3 does not specify how the AM detects the request manifest type, but it does specify that the AM should reply with a manifest RSpec in the same format as the request RSpec. So another option is to specify only the request RSpec type, and return a manifest of the same RSpec type.

This probably isn't easier to implement however, as the AM is still required to translate the manifest RSpec if the client issues a Describe call and requests another format.
# How to change the API:

This issue contains a proposal on how to change the API to include both RSpec versions. This is meant to demonstrate how this could be done. It will be updated based on the result of discussing the above.

(If this proposal is a good idea, it might be added to the API in a cleaner way, so any feedback on that is also appreciated! For example, argument 3, the "struct rspec" now contains both the type, version and the rspec itself. Would it be better to split this up? Also, the manifest_rspec_type could also be an option instead of a mandatory argument, and when not specified, it could default to the same version as the request. )
