### PR TITLE
location is optional in manifest

### DIFF
--- a/rspec.adoc
+++ b/rspec.adoc
@@ -411,7 +411,7 @@ If true, the node is available. If not, the node is not available.
 [horizontal]
 In advertisement:: optional
 In request:: no
-In manifest:: no
+In manifest:: optional
 ***********************************
 
 ///////////////////////


### PR DESCRIPTION
Fixed a mistake in the document: the location element is optional in the manifest, instead of forbidden.