### PR TITLE
Add INSUFFICIENT_RESOURCES reply

### DIFF
--- a/call-basics.adoc
+++ b/call-basics.adoc
@@ -246,6 +246,11 @@ INSUFFICIENT_BANDWIDTH::
    Error Nr;; 25
    Calls;; ?
    Meaning;; Requested capacity for link(s) not available
+INSUFFICIENT_RESOURCES::
+[horizontal]
+   Error Nr;; 26
+   Calls;; ?
+   Meaning;; One or more resources in the request could not be allocated, because all suitable resources are in use or reserved. Typical scenarios for this error are: no physical nodes available, no pyshical nodes with the requested number of interfaces available, not possible to create an additional VM. This might also occur when no link is possible between 2 nodes. There is also possible overlap between this error and INSUFFICIENT_BANDWIDTH.
 
 ==== Examples
 


### PR DESCRIPTION
There currently is no standardized reply when no physical nodes available, no pyshical nodes with the requested number of interfaces available or it is not possible to create an additional VM.
A new reply code would be useful for these cases, where the requested resources could not be allocated.

This reply code would enable clients to easily detect this case. That would allow jFed to inform the user of the reason for the failure, and would allow "fedmon", the fed4fire FLS monitor, to flag these failures as a login test warning instead of a failure.

(Feedback is needed about the name of the error code, the value, and the exact cases targeted by this error. The possible overlap with INSUFFICIENT_BANDWIDTH should also be handled.)